### PR TITLE
Set GitHub Pages domain to default

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.joshvendrow.com
+ludwigvsch.github.io


### PR DESCRIPTION
## Summary
- update the CNAME record to point the site to the default GitHub Pages domain `ludwigvsch.github.io`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0d814ce48329ba9e09b6fa4d8d4a